### PR TITLE
Update env examples with new Vercel link

### DIFF
--- a/docker/.env.example
+++ b/docker/.env.example
@@ -64,7 +64,7 @@ BLOB_STORAGE_PATH=/root/.flowise/storage
 ############################################################################################################
 
 # NUMBER_OF_PROXIES= 1
-# CORS_ORIGINS=https://flowise-m6oiaisko-marcus-thomas-projects-90ba4767.vercel.app,https://flowise-ui-liart.vercel.app,https://localhost:3000
+# CORS_ORIGINS=https://flowise-ui-liart.vercel.app,https://localhost:3000
 # IFRAME_ORIGINS=*
 # FLOWISE_FILE_SIZE_LIMIT=50mb
 # SHOW_COMMUNITY_NODES=true

--- a/docker/worker/.env.example
+++ b/docker/worker/.env.example
@@ -64,7 +64,7 @@ BLOB_STORAGE_PATH=/root/.flowise/storage
 ############################################################################################################
 
 # NUMBER_OF_PROXIES= 1
-# CORS_ORIGINS=https://flowise-m6oiaisko-marcus-thomas-projects-90ba4767.vercel.app,https://flowise-ui-liart.vercel.app,https://localhost:3000
+# CORS_ORIGINS=https://flowise-ui-liart.vercel.app,https://localhost:3000
 # IFRAME_ORIGINS=*
 # FLOWISE_FILE_SIZE_LIMIT=50mb
 # SHOW_COMMUNITY_NODES=true


### PR DESCRIPTION
## Summary
- update example CORS_ORIGINS values to use new Vercel app URL

## Testing
- `pnpm test` *(fails: Cannot find module 'flowise-components')*

------
https://chatgpt.com/codex/tasks/task_e_684fb468a938833394685005d97acf8d