### PR TITLE
Update settings fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "user": "run-script-os",
         "user:windows": "cd packages/server/bin && run user",
         "user:default": "cd packages/server/bin && ./run user",
-        "test": "turbo run test",
+        "test": "pnpm --filter ./packages/components build && turbo run test",
         "clean": "pnpm --filter \"./packages/**\" clean",
         "nuke": "pnpm --filter \"./packages/**\" nuke && rimraf node_modules .turbo",
         "format": "prettier --write \"**/*.{ts,tsx,md}\"",

--- a/packages/ui/src/api/platformsettings.js
+++ b/packages/ui/src/api/platformsettings.js
@@ -1,6 +1,10 @@
-import client from './client'
-
-const getSettings = () => client.get('/settings')
+const getSettings = async () => {
+    const response = await fetch(`${process.env.NEXT_PUBLIC_API_URL}/api/v1/settings`, {
+        credentials: 'include'
+    })
+    const data = await response.json()
+    return { data }
+}
 
 export default {
     getSettings


### PR DESCRIPTION
## Summary
- switch platform settings API to `fetch` using `NEXT_PUBLIC_API_URL`
- build components package before running tests

## Testing
- `pnpm test` *(timed out during server startup)*

------
https://chatgpt.com/codex/tasks/task_e_68508c45c62883338f7126897a427614