### PR TITLE
Fix CORS handling and add robust fetch utility

### DIFF
--- a/packages/server/src/index.ts
+++ b/packages/server/src/index.ts
@@ -165,7 +165,7 @@ export class App {
         // Parse cookies
         this.app.use(cookieParser())
 
-        const allowedOrigins = ['https://flowise-772e48kex-marcus-thomas-projects-90ba4767.vercel.app', 'http://localhost:3000']
+        const allowedOrigins = ALLOWED_ORIGINS
         this.app.use((req, res, next) => {
             const origin = req.headers.origin as string | undefined
             if (origin && allowedOrigins.includes(origin)) {
@@ -175,6 +175,7 @@ export class App {
                 res.setHeader('Access-Control-Allow-Credentials', 'true')
             }
             if (req.method === 'OPTIONS') {
+                res.setHeader('Content-Type', 'application/json')
                 return res.status(204).end()
             }
             next()

--- a/packages/ui/src/utils/api.ts
+++ b/packages/ui/src/utils/api.ts
@@ -1,11 +1,35 @@
 const baseUrl = process.env.NEXT_PUBLIC_USE_PROXY === 'true' ? '/api/flowise' : 'https://flowise-ai-cqlx.onrender.com/api/v1'
 
-export async function api<T>(endpoint: string, opts: RequestInit = {}) {
+export async function api<T>(endpoint: string, opts: RequestInit = {}, retries = 1) {
     const url = `${baseUrl}/${endpoint.replace(/^\/+/, '')}`
-    const res = await fetch(url, { ...opts, credentials: 'include' })
-    if (!res.ok) {
-        const text = await res.text().catch(() => '')
-        throw new Error(`HTTP ${res.status} – ${text || res.statusText}`)
+    const headers = {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        ...(opts.headers || {})
     }
-    return res.json() as Promise<T>
+    try {
+        const res = await fetch(url, {
+            ...opts,
+            headers,
+            credentials: 'include'
+        })
+        if (!res.ok) {
+            const text = await res.text().catch(() => '')
+            if (retries > 0) {
+                return api<T>(endpoint, opts, retries - 1)
+            }
+            throw new Error(`HTTP ${res.status} – ${text || res.statusText}`)
+        }
+        try {
+            return (await res.json()) as T
+        } catch (e) {
+            const text = await res.text().catch(() => '')
+            return text as any
+        }
+    } catch (err) {
+        if (retries > 0) {
+            return api<T>(endpoint, opts, retries - 1)
+        }
+        throw err
+    }
 }

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+    "rewrites": [{ "source": "/api/flowise/:path*", "destination": "https://flowise-ai-cqlx.onrender.com/api/v1/:path*" }]
+}


### PR DESCRIPTION
## Summary
- allow Vercel origin and handle OPTIONS requests
- add retry/JSON-safe API helper in UI
- support proxy rewriting with `vercel.json`

## Testing
- `pnpm lint`
- `pnpm test`


------
https://chatgpt.com/codex/tasks/task_e_6850ef611b1883339e552178e2a29e01